### PR TITLE
Solved bug in edit page where assignee would not get changed

### DIFF
--- a/src/app/body/task-details/edit-page/edit-page.component.html
+++ b/src/app/body/task-details/edit-page/edit-page.component.html
@@ -99,7 +99,9 @@
                                     <div class="col">
                                         <span class="header">Assignee:</span>
                                     </div>
-                                    <div class="col"><input type="text" class="form-control" [(ngModel)]="logWorkComment" [ngModelOptions]="{standalone: true}"></div>
+                                    <div class="col">
+                                        <input type="text" class="form-control" [(ngModel)]="editTask.Assignee" [ngModelOptions]="{standalone: true}">
+                                    </div>
                                 </div>
                                 <hr>
                                 <div class="row" id="non-editable">


### PR DESCRIPTION
Signed-off-by: Arjun Dave <davearjun25@gmail.com>

### Functionality:
Solves the error where the assignee name wouldn't get edited in the edit page.

### Solution:
Corrected the error in the assignee variable name.

### Risk level:
- [ ] high 
- [ ] medium
- [X] low

### How to test:
1. firebase emulators:start 
2. ng serve
3. Try to edit a task after creating the task and sprint.
