### PR TITLE
Feat(dev/bugFix): Fixed the bug in Patch1

### DIFF
--- a/functions/model/patch/patch1.js
+++ b/functions/model/patch/patch1.js
@@ -76,7 +76,7 @@ function sprintCounters(i, orgDomain, teamId, teamName, fullSprintId) {
             TotalUnCompletedTask: a[2],
         };
 
-        const p1 = updateSprint(updateSprintInputJson, orgDomain, teamName, fullsprintId);
+        const p1 = updateSprint(updateSprintInputJson, orgDomain, teamName, fullSprintId);
         return Promise.resolve(p1);
     });
 }


### PR DESCRIPTION
### Functionality:
There was a typing error in patch1 file. The variable 'fullSprintId' was not typed correctly which was causing errors while running patch1.

### Solution:
Corrected it.

### Risk level:
- [ ] high 
- [ ] medium
- [x] low

### How to test:
ng serve
firebase emulators:start
Try running Patch1.
